### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,7 @@ source /usr/share/yunohost/helpers
 email=$(ynh_user_get_info --username="$admin" --key="mail")
 firstname=$(ynh_user_get_info --username="$admin" --key="firstname")
 lastname=$(ynh_user_get_info --username="$admin" --key="lastname")
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.